### PR TITLE
Removed Ahoy, Task and Goss.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -155,19 +155,6 @@ RUN version=1.22.22 && \
     npm cache clean --force && \
     yarn --version
 
-# Install Goss.
-# @see https://github.com/goss-org/goss/releases
-# renovate: datasource=github-releases depName=aelsabbahy/goss extractVersion=^v(?<version>.*)$
-ENV GOSS_FILES_STRATEGY=cp
-# See https://github.com/goss-org/goss/releases for release versions
-# hadolint ignore=DL4006
-RUN version=0.4.9 && \
-    curl -L "https://github.com/goss-org/goss/releases/download/v${version}/goss-linux-amd64" -o /usr/local/bin/goss && \
-    chmod +rx /usr/local/bin/goss && \
-    curl -L "https://github.com/goss-org/goss/releases/download/v${version}/dgoss" -o /usr/local/bin/dgoss && \
-    chmod +rx /usr/local/bin/dgoss && \
-    goss --version
-
 # Install Bats.
 # @see https://github.com/bats-core/bats-core/releases
 # renovate: datasource=github-releases depName=bats-core/bats-core extractVersion=^(?<version>.*)$
@@ -179,20 +166,6 @@ RUN version=1.12.0 && \
     ./install.sh /usr/local && \
     rm -rf /tmp/bats* && \
     bats -v
-
-# Install Ahoy.
-# @see https://github.com/ahoy-cli/ahoy/releases
-# renovate: datasource=github-releases depName=ahoy-cli/ahoy extractVersion=^(?<version>.*)$
-RUN version=2.4.0 && \
-    set -x && curl -L -o "/usr/local/bin/ahoy" "https://github.com/ahoy-cli/ahoy/releases/download/v${version}/ahoy-bin-$(uname -s)-amd64" && \
-    chmod +x /usr/local/bin/ahoy && \
-    ahoy --version
-
-# Install Task.
-# @see https://github.com/go-task/task/releases
-# renovate: datasource=github-releases depName=go-task/task extractVersion=^(?<version>.*)$
-RUN version=3.44.0 && \
-    sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -b /usr/local/bin "v$version"
 
 # Install Codecov reporter.
 # @see https://github.com/codecov/uploader/releases

--- a/goss.yaml
+++ b/goss.yaml
@@ -14,13 +14,6 @@ command:
     stderr: []
     timeout: 10000
 
-  which ahoy:
-    exit-status: 0
-    stdout:
-      - /usr/local/bin/ahoy
-    stderr: []
-    timeout: 10000
-
   which aspell:
     exit-status: 0
     stdout:
@@ -79,13 +72,6 @@ command:
 
   test -d $HOME/.gnupg:
     exit-status: 0
-    stderr: []
-    timeout: 10000
-
-  which goss:
-    exit-status: 0
-    stdout:
-      - /usr/local/bin/goss
     stderr: []
     timeout: 10000
 
@@ -191,13 +177,6 @@ command:
     exit-status: 0
     stdout:
       - /usr/bin/ssh
-    stderr: []
-    timeout: 10000
-
-  which task:
-    exit-status: 0
-    stdout:
-      - /usr/local/bin/task
     stderr: []
     timeout: 10000
 

--- a/versions.sh
+++ b/versions.sh
@@ -6,7 +6,6 @@ set -e
 DOCKER_IMAGE="${1}"
 
 commands=(
-  "ahoy --version"
   "aspell --version"
   "bats --version"
   "composer --version"
@@ -16,7 +15,6 @@ commands=(
   "docker buildx version"
   "docker compose version"
   "git --version"
-  "goss --version"
   "gpg --version"
   "jq --version"
   "kcov --version"
@@ -30,7 +28,6 @@ commands=(
   "shellcheck --version"
   "shfmt --version"
   "ssh -V"
-  "task --version"
   "tree --version"
   "unzip -v"
   "vim --version"


### PR DESCRIPTION
Ahoy and Task are local helpers and are not expected to be used in CI.

Goss is a very niche tool. It is not required in most of the cases.